### PR TITLE
feat: compile TS for build and clean up

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,28 @@
-FROM node:22-alpine
+FROM node:22-alpine AS base
 
 WORKDIR /app
 
 # Copy only these first to leverage Docker cache
-COPY package.json package-lock.json ./
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 
-RUN npm ci
+RUN corepack enable
 
+# Compile TS
+FROM base AS builder
+RUN pnpm install --frozen-lockfile
 COPY . .
+RUN pnpm build
+
+# Install production dependencies
+FROM base AS deps
+RUN pnpm install --prod --frozen-lockfile
+
+# Bare minimum image for production
+FROM node:22-alpine
+WORKDIR /app
+
+COPY --from=builder /app/dist ./dist
+COPY --from=deps /app/package.json ./
+COPY --from=deps /app/node_modules ./node_modules
 
 CMD ["npm", "start"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,4 @@ services:
       - "3000:3000"
     environment:
       - PORT=3000
-    volumes:
-      - .:/app
     restart: unless-stopped

--- a/package.json
+++ b/package.json
@@ -3,8 +3,9 @@
   "version": "1.0.0",
   "description": "Microservice to serve freeCodeCamp challenges",
   "scripts": {
+    "build": "tsc --project tsconfig-build.json",
     "develop": "DEBUG=app* tsx watch src/server.js",
-    "start": "DEBUG=app* node src/server.js",
+    "start": "DEBUG=app* node dist/server.js",
     "seed": "tsx database/seed.js",
     "test": "jest --force-exit"
   },
@@ -29,5 +30,6 @@
     "ts-jest": "^29.3.2",
     "ts-node": "^10.9.2",
     "tsx": "^4.19.3"
-  }
+  },
+  "packageManager": "pnpm@10.11.0+sha512.6540583f41cc5f628eb3d9773ecee802f4f9ef9923cc45b69890fb47991d4b092964694ec3a4f738a420c918a333062c8b925d312f42e4f0c263eb603551f977"
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+onlyBuiltDependencies:
+  - esbuild

--- a/tsconfig-build.json
+++ b/tsconfig-build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "outDir": "dist",
+    "noEmit": false
+  },
+  "include": ["src"],
+  "exclude": ["**/*.test.*"]
+}


### PR DESCRIPTION
For Docker a multistage build keeps the image size down (saving ~100MB). Also, there's no need to mount the source, so I didn't.

I added a build tsconfig so that we can ignore tests and tooling (/database) while building and keep the existing tsconfig for development.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

<!-- Feel free to add any additional description of changes below this line -->
